### PR TITLE
Reduce scope of JUnit dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,12 +11,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>3.8.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
             <version>4.7</version>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.7</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     


### PR DESCRIPTION
By setting the scope of the JUnit dependency to `test`, JUnit is no longer a transitive dependency for projects relying on this library (I think my terminology is correct).

This means that:
```
compile ('com.github.nicolas-raoul:Quadtree:XXX') {
    exclude module: 'junit'
}
```
can be replaced with:
```
compile 'com.github.nicolas-raoul:Quadtree:XXX'
```